### PR TITLE
MIDI Cleanup and Enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/webmidi": "^2.1.0",
         "@typescript-eslint/eslint-plugin": "^8.1.0",
         "@typescript-eslint/parser": "^8.1.0",
         "eslint": "^8.57.0",
@@ -1103,6 +1104,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/webmidi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.1.0.tgz",
+      "integrity": "sha512-k898MjEUSHB+6rSeCPQk/kLgie0wgWZ2t78GlWj86HbTQ+XmtbBafYg5LNjn8bVHfItEhPGZPf579Xfc6keV6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.26.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/webmidi": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^8.1.0",
     "@typescript-eslint/parser": "^8.1.0",
     "eslint": "^8.57.0",

--- a/src/app/_components/PianoKeyboard.tsx
+++ b/src/app/_components/PianoKeyboard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+/// <reference types="webmidi" />
+
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { NoteName, ChordInfo, MIDIMessage } from "./chordUtils";
 import {

--- a/src/app/_components/PianoKeyboard.tsx
+++ b/src/app/_components/PianoKeyboard.tsx
@@ -174,7 +174,7 @@ export const PianoKeyboard: React.FC = () => {
     2: new Set<number>(),
     3: new Set<number>(),
   });
-  
+
   const [keyColors, setKeyColors] = useState<Record<string, string>>({});
   const [midiDevice, setMidiDevice] = useState<string>(
     "No MIDI device connected",
@@ -230,7 +230,9 @@ export const PianoKeyboard: React.FC = () => {
 
       // Handle notes by channel
       const updatedNotes = { ...activeNotesRef.current };
-      const channelNotes = new Set<number>(updatedNotes[channel] ?? new Set<number>());
+      const channelNotes = new Set<number>(
+        updatedNotes[channel] ?? new Set<number>(),
+      );
 
       if (isNoteOn) {
         channelNotes.add(noteNumber);

--- a/src/app/_components/chordUtils.ts
+++ b/src/app/_components/chordUtils.ts
@@ -501,3 +501,82 @@ export const getVoicingsForQuality = (
       return MAJOR_VOICINGS;
   }
 };
+
+// Define MIDI message type for better organization
+export type MIDIMessageType =
+  | "note-on"
+  | "note-off"
+  | "control-change"
+  | "program-change"
+  | "unknown";
+
+export interface MIDIMessage {
+  timestamp: number;
+  channel: number;
+  type: MIDIMessageType;
+  noteNumber?: number;
+  noteName?: string;
+  velocity?: number;
+  controlNumber?: number;
+  controlValue?: number;
+  programNumber?: number;
+  rawData: number[];
+}
+
+export const parseMIDIMessage = (
+  data: Uint8Array,
+  timestamp: number
+): MIDIMessage | null => {
+  if (data.length < 1) return null;
+
+  const statusByte = data?.[0];
+  const messageType = statusByte ? statusByte >> 4 : 0;
+  const channel = statusByte ? (statusByte & 0x0f) + 1 : 0;
+
+  let type: MIDIMessageType = "unknown";
+  let noteNumber: number | undefined;
+  let noteName: string | undefined;
+  let velocity: number | undefined;
+  let controlNumber: number | undefined;
+  let controlValue: number | undefined;
+  let programNumber: number | undefined;
+
+  // Note-on message
+  if (messageType === 9) {
+    type = data?.[2] !== undefined && data[2] > 0 ? "note-on" : "note-off"; // Note-on with velocity 0 is treated as note-off
+    noteNumber = data[1];
+    noteName = noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
+    velocity = data[2];
+  }
+  // Note-off message
+  else if (messageType === 8) {
+    type = "note-off";
+    noteNumber = data[1];
+    noteName = noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
+    velocity = data[2];
+  }
+  // Control change
+  else if (messageType === 11) {
+    type = "control-change";
+    controlNumber = data[1];
+    controlValue = data[2];
+  }
+  // Program change
+  else if (messageType === 12) {
+    type = "program-change";
+    programNumber = data[1];
+  }
+
+  return {
+    timestamp,
+    channel,
+    type,
+    noteNumber,
+    noteName,
+    velocity,
+    controlNumber,
+    controlValue,
+    programNumber,
+    rawData: Array.from(data),
+  };
+};

--- a/src/app/_components/chordUtils.ts
+++ b/src/app/_components/chordUtils.ts
@@ -525,7 +525,7 @@ export interface MIDIMessage {
 
 export const parseMIDIMessage = (
   data: Uint8Array,
-  timestamp: number
+  timestamp: number,
 ): MIDIMessage | null => {
   if (data.length < 1) return null;
 
@@ -545,14 +545,16 @@ export const parseMIDIMessage = (
   if (messageType === 9) {
     type = data?.[2] !== undefined && data[2] > 0 ? "note-on" : "note-off"; // Note-on with velocity 0 is treated as note-off
     noteNumber = data[1];
-    noteName = noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
+    noteName =
+      noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
     velocity = data[2];
   }
   // Note-off message
   else if (messageType === 8) {
     type = "note-off";
     noteNumber = data[1];
-    noteName = noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
+    noteName =
+      noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
     velocity = data[2];
   }
   // Control change

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,3 +1,4 @@
+/// <reference types="webmidi" />
 "use client";
 
 import { useState, useEffect, useCallback } from "react";

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { parseMIDIMessage, MIDIMessage } from "../_components/chordUtils";
+import { parseMIDIMessage } from "../_components/chordUtils";
+import type { MIDIMessage } from "../_components/chordUtils";
 
 // Format timestamp to human-readable format
 const formatTimestamp = (timestamp: number): string => {
@@ -56,9 +57,9 @@ const DebugPage: React.FC = () => {
 
   // Handler for incoming MIDI messages
   const handleMIDIMessage = useCallback(
-    (event: MIDIMessageEvent) => {
+    (event: WebMidi.MIDIMessageEvent) => {
       const timestamp = performance.now();
-      const data = event.data!;
+      const data = event.data;
       const parsedMessage = parseMIDIMessage(data, timestamp);
 
       if (parsedMessage) {
@@ -85,7 +86,11 @@ const DebugPage: React.FC = () => {
       return;
     }
 
-    (navigator as Navigator & { requestMIDIAccess(): Promise<MIDIAccess> })
+    (
+      navigator as Navigator & {
+        requestMIDIAccess(): Promise<WebMidi.MIDIAccess>;
+      }
+    )
       .requestMIDIAccess()
       .then((access) => {
         // Get available devices
@@ -104,7 +109,7 @@ const DebugPage: React.FC = () => {
         }
 
         // Handle device connection/disconnection
-        access.onstatechange = (event) => {
+        access.onstatechange = (event: WebMidi.MIDIConnectionEvent) => {
           if (
             event.port &&
             "type" in event.port &&

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,28 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { getMIDINoteName } from "../_components/chordUtils";
-
-// Define MIDI message type for better organization
-type MIDIMessageType =
-  | "note-on"
-  | "note-off"
-  | "control-change"
-  | "program-change"
-  | "unknown";
-
-interface MIDIMessage {
-  timestamp: number;
-  channel: number;
-  type: MIDIMessageType;
-  noteNumber?: number;
-  noteName?: string;
-  velocity?: number;
-  controlNumber?: number;
-  controlValue?: number;
-  programNumber?: number;
-  rawData: number[];
-}
+import { parseMIDIMessage, MIDIMessage } from "../_components/chordUtils";
 
 // Format timestamp to human-readable format
 const formatTimestamp = (timestamp: number): string => {
@@ -46,67 +25,6 @@ const DebugPage: React.FC = () => {
   const [connectedDevice, setConnectedDevice] = useState<string>("No device");
   const [maxMessages] = useState<number>(500);
   const [filterNoteOff, setFilterNoteOff] = useState<boolean>(false);
-
-  // Parse MIDI data to structured format
-  const parseMIDIMessage = useCallback(
-    (data: Uint8Array, timestamp: number): MIDIMessage | null => {
-      if (data.length < 1) return null;
-
-      const statusByte = data?.[0];
-      const messageType = statusByte ? statusByte >> 4 : 0;
-      const channel = statusByte ? (statusByte & 0x0f) + 1 : 0;
-
-      let type: MIDIMessageType = "unknown";
-      let noteNumber: number | undefined;
-      let noteName: string | undefined;
-      let velocity: number | undefined;
-      let controlNumber: number | undefined;
-      let controlValue: number | undefined;
-      let programNumber: number | undefined;
-
-      // Note-on message
-      if (messageType === 9) {
-        type = data?.[2] !== undefined && data[2] > 0 ? "note-on" : "note-off"; // Note-on with velocity 0 is treated as note-off
-        noteNumber = data[1];
-        noteName =
-          noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
-        velocity = data[2];
-      }
-      // Note-off message
-      else if (messageType === 8) {
-        type = "note-off";
-        noteNumber = data[1];
-        noteName =
-          noteNumber !== undefined ? getMIDINoteName(noteNumber) : undefined;
-        velocity = data[2];
-      }
-      // Control change
-      else if (messageType === 11) {
-        type = "control-change";
-        controlNumber = data[1];
-        controlValue = data[2];
-      }
-      // Program change
-      else if (messageType === 12) {
-        type = "program-change";
-        programNumber = data[1];
-      }
-
-      return {
-        timestamp,
-        channel,
-        type,
-        noteNumber,
-        noteName,
-        velocity,
-        controlNumber,
-        controlValue,
-        programNumber,
-        rawData: Array.from(data),
-      };
-    },
-    [],
-  );
 
   // Filter messages based on selected channel
   const filterMessages = useCallback(
@@ -157,7 +75,7 @@ const DebugPage: React.FC = () => {
         });
       }
     },
-    [parseMIDIMessage, maxMessages],
+    [maxMessages],
   );
 
   // Effect for MIDI access initialization


### PR DESCRIPTION
- Move MIDI parsing into chordUtils
- Update PianoKeyboard to use new MIDI parsing
- Add support for all 3 MIDI channels
  - 1: Performance - used highlighting keys
  - 2: Bass - bass now shows up as a black line on keys
  - 3: Chords - the chord display uses these chords
- Simplified parsing of Midi notes to remove redundant code
- Simplify channel handling to not require new data structure for each channel.
- Rename isBassBorder to isBassNote